### PR TITLE
[Draft] フロントカメラVer調査経過（左右逆に描画される）

### DIFF
--- a/app/src/main/java/biz/moapp/motion_scanner/ui/CameraPreview.kt
+++ b/app/src/main/java/biz/moapp/motion_scanner/ui/CameraPreview.kt
@@ -107,8 +107,8 @@ fun CameraPreview(
                                     MotionAnalyzeUseCase(cameraViewModel).analyze(imageProxy)
                                 })
 
-                            /**背面のカメラを選択**/
-                            val cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
+                            /**前面のカメラを選択**/
+                            val cameraSelector = CameraSelector.DEFAULT_FRONT_CAMERA
                             try {
                                 /**バインドされているユースケースがあれば、すべて解除する**/
                                 cameraProvider.unbindAll()


### PR DESCRIPTION
- フロントカメラ設定
- 左右の座標を入れ替えて、線を描画
→想定通りの表示にはならず、左右逆表示のまま。

MLのライブラリでは反転して読み取ることは不可能そう
（以下のように取得するポーズの位置は決まっており、ライブラリ見た感じ反転できる設定とかなさそう）
<img width="751" alt="スクリーンショット 2024-08-27 15 53 31" src="https://github.com/user-attachments/assets/3ed1d0d7-68f5-4631-9011-553d588569fe">
[引用元：Pose detection](https://developers.google.com/ml-kit/vision/pose-detection?hl=ja)

フロントカメラの読み取り設定を反転なしにするのも調べてみたが、特に何もヒットせず。
「android kotlin camerax フロントカメラ 反転制御」

- [これは端末に対してカメラの向きの話なので関係なし？](https://developer.android.com/media/camera/camera2/camera-preview?hl=ja#front-facing_cameras)

- [カメラプレビューの実装](https://developer.android.com/media/camera/camerax/preview?hl=ja)